### PR TITLE
Ignore site hooks support

### DIFF
--- a/SCRAM/Configuration/ConfigArea.py
+++ b/SCRAM/Configuration/ConfigArea.py
@@ -73,11 +73,9 @@ class ConfigArea(object):
                 localarea.bootstrapfromlocation(self.location())
             if localarea and localarea.configchksum() != self.configchksum():
                 err = "ERROR: Can not setup your current working area for " \
-                      "SCRAM_ARCH: $ENV{SCRAM_ARCH}\n"
-                err += "Your current development area ${location}/${" \
-                       "areaname}\n"
-                err += "is using a different ${areaname}/config then the " \
-                       "one used for\n"
+                      "SCRAM_ARCH: %s\n" % environ['SCRAM_ARCH']
+                err += "Your current development area %s\n" % location
+                err += "is using a different config tag then the one used for release\n"
                 err += self.releasetop()
                 print(err, file=stderr)
                 exit(1)

--- a/SCRAM/Core/Commands/project.py
+++ b/SCRAM/Core/Commands/project.py
@@ -147,15 +147,19 @@ def project_bootfromrelease(project, version, releasePath, opts):
     if tc:
         tc.getData(version, relarea.location())
     if 'SCRAM_IGNORE_PROJECT_HOOK' not in environ:
-        proj_hook = join(localarea.config(), 'SCRAM', 'hooks', 'project-hook')
+        hook_dir = join(localarea.config(), 'SCRAM', 'hooks')
+        proj_hook = join(hook_dir, 'project-hook')
         if exists(proj_hook):
             SCRAM.run_command(proj_hook)
-    if 'SCRAM_IGNORE_SITE_PROJECT_HOOK' not in environ:
-        proj_hook = join(SCRAM.get_site_hooks(), 'SCRAM', 'hooks', 'project-hook')
-        if exists(proj_hook):
-            err, out = SCRAM.run_command(proj_hook)
-            if out:
-                SCRAM.printmsg(out)
+        if 'SCRAM_IGNORE_SITE_PROJECT_HOOK' not in environ:
+            proj_hook = join(SCRAM.get_site_hooks(), 'SCRAM', 'hooks', 'project-hook')
+            if exists(proj_hook):
+                ignore_hooks_file = join(hook_dir, 'ignore-site-hooks')
+                if not exists(ignore_hooks_file):
+                    ignore_hooks_file=""
+                err, out = SCRAM.run_command("SCRAM_IGNORE_HOOKS=%s %s" % (ignore_hooks_file, proj_hook))
+                if out:
+                    SCRAM.printmsg(out)
     if '/afs/cern.ch/' in environ['SCRAM_TOOL_HOME']:
         msg = "****************************** WARNING ******************************\n" \
               "You are using CMSSW from CERN AFS space. Please note that, by the start of 2017, " \


### PR DESCRIPTION
This change allows to ignore some site specific hooks e.g. for releases where a fix to runtime env has been appied then there is no need to run the site specific hook to fix that issue.

This is useful for https://github.com/cms-sw/cms-common/blob/master/etc/scramrc/SCRAM/hooks/runtime/99-gsl-config.sh where gsl tool has been fixed for 14.0.X and there is no need to run this hook in 14.0.X release cycle