### PR TITLE
Add shorthand way of setting SCRAM_ARCH together with project

### DIFF
--- a/SCRAM/Core/Commands/project.py
+++ b/SCRAM/Core/Commands/project.py
@@ -59,6 +59,8 @@ def process(args):
     
     if not project.startswith("/") and len(project.split("/")) == 2:
         newarch, newproject = project.split("/")
+        if newarch.startswith("CMSSW_"):
+            newarch, newproject = newproject, newarch
 
         if SCRAM.FORCED_ARCH is not None:
             SCRAM.scramwarning("Overriding --arch with value " + newarch)

--- a/SCRAM/Core/Commands/project.py
+++ b/SCRAM/Core/Commands/project.py
@@ -56,6 +56,16 @@ def process(args):
     if len(args) == 0:
         SCRAM.scramfatal("Error parsing arguments. See \"scram -help\" for usage info.")
     project = args[0]
+    
+    if not project.startswith("/") and len(project.split("/")) == 2:
+        newarch, newproject = project.split("/")
+
+        if SCRAM.FORCED_ARCH is not None:
+            SCRAM.scramwarning("Overriding --arch with value " + newarch)
+        SCRAM.FORCED_ARCH = newarch
+        environ["SCRAM_ARCH"] = newarch
+        project = newproject
+    
     version = args[1] if len(args) > 1 else None
     releasePath = None
     if version is None:


### PR DESCRIPTION
`scram project el8_amd64_gcc12/CMSSW_14_1_ROOT6_X_2024-02-19-2300` and `scram project CMSSW_14_1_ROOT6_X_2024-02-19-2300/el8_amd64_gcc12` are shorthands for `scram -a el8_amd64_gcc12 project CMSSW_14_1_ROOT6_X_2024-02-19-2300` - useful for testing IB failures by copying part of the log URL (`https://cmssdt.cern.ch/SDT/cgi-bin/logreader/**el8_amd64_gcc12/CMSSW_14_1_ROOT6_X_2024-02-19-2300**/unitTestLogs/Validation/Geometry#/13-13`)

