### PR TITLE
fix typo in `scramfatal` message

### DIFF
--- a/SCRAM/Core/Commands/project.py
+++ b/SCRAM/Core/Commands/project.py
@@ -54,7 +54,7 @@ def process(args):
     if opts.bootstrap:
         return project_bootnewproject(opts, args)
     if len(args) == 0:
-        SCRAM.scramfatal("Error parsing arguments. See \"scram -help\" for usage info.")
+        SCRAM.scramfatal("Error parsing arguments. See \"scram --help\" for usage info.")
     project = args[0]
     version = args[1] if len(args) > 1 else None
     releasePath = None
@@ -76,7 +76,7 @@ def project_bootfromrelease(project, version, releasePath, opts):
     installname = opts.install_name if opts.install_name else version
     relarea = None
     if not (project and version):
-        SCRAM.scramfatal("Insufficient arguments: see \"scram project -help\" for usage info.")
+        SCRAM.scramfatal("Insufficient arguments: see \"scram project --help\" for usage info.")
     from SCRAM.Core.ProjectDB import ProjectDB
     db = ProjectDB()
     relarea = None
@@ -173,7 +173,7 @@ def project_bootfromrelease(project, version, releasePath, opts):
 
 def project_bootnewproject(opts, args):
     if len(args) != 0:
-        SCRAM.scramfatal("Error parsing arguments. See \"scram -help\" for usage info.")
+        SCRAM.scramfatal("Error parsing arguments. See \"scram --help\" for usage info.")
     from SCRAM.Configuration.BootStrapProject import BootStrapProject
     bootstrapfile = opts.bootstrap
     if opts.install_base_dir is None:

--- a/SCRAM/Core/Commands/runtime.py
+++ b/SCRAM/Core/Commands/runtime.py
@@ -10,7 +10,7 @@ def clean_build_env():
 
 def process_unsetenv(args):
     if (len(args) != 1) or (args[0] not in RUNTIME_SHELLS):
-        SCRAM.scramfatal("Error parsing arguments. See \"scram -help\" for usage info.")
+        SCRAM.scramfatal("Error parsing arguments. See \"scram --help\" for usage info.")
     clean_build_env()
     rt = RuntimeEnv(area=None)
     rt.unsetenv(RUNTIME_SHELLS[args[0]])
@@ -19,7 +19,7 @@ def process_unsetenv(args):
 
 def process_runtime(args):
     if (len(args) == 0) or (args[0] not in RUNTIME_SHELLS):
-        SCRAM.scramfatal("Error parsing arguments. See \"scram -help\" for usage info.")
+        SCRAM.scramfatal("Error parsing arguments. See \"scram --help\" for usage info.")
     from SCRAM.Core.Core import Core
     clean_build_env()
     area = Core()

--- a/SCRAM/Core/Commands/setup.py
+++ b/SCRAM/Core/Commands/setup.py
@@ -16,7 +16,7 @@ def process(args):
                         help='Obsolete command-line argument')
     opts, args = parser.parse_known_args(args)
     if len(args) > 1:
-        SCRAM.scramfatal("Error parsing arguments. See \"scram -help\" for usage info.")
+        SCRAM.scramfatal("Error parsing arguments. See \"scram --help\" for usage info.")
     area = Core()
     area.checklocal()
     area.init_env()

--- a/SCRAM/Core/Commands/tool.py
+++ b/SCRAM/Core/Commands/tool.py
@@ -8,7 +8,7 @@ def process(args):
     area = Core()
     area.checklocal()
     if not args or args[0].lower() not in ['list', 'info', 'tag', 'remove']:
-        SCRAM.scramfatal("Error parsing arguments. See \"scram -help\" for usage info.")
+        SCRAM.scramfatal("Error parsing arguments. See \"scram --help\" for usage info.")
     return eval('tool_%s' % args[0].lower())(args[1:], area.localarea())
 
 
@@ -28,7 +28,7 @@ def tool_list(args, area):
 
 def tool_info(args, area):
     if not args:
-        SCRAM.scramfatal("No tool name given: see \"scram tool -help\" for usage info.")
+        SCRAM.scramfatal("No tool name given: see \"scram tool --help\" for usage info.")
 
     from SCRAM.BuildSystem.ToolFile import ToolFile
     toolmanager = ToolManager(area)
@@ -54,7 +54,7 @@ def tool_info(args, area):
 
 def tool_tag(args, area):
     if len(args) < 1:
-        SCRAM.scramfatal("No tool name given: see \"scram tool -help\" for usage info.")
+        SCRAM.scramfatal("No tool name given: see \"scram tool --help\" for usage info.")
 
     toolmanager = ToolManager(area)
     toolname = args[0].lower()
@@ -71,7 +71,7 @@ def tool_tag(args, area):
 
 def tool_remove(args, area):
     if len(args) < 1:
-        SCRAM.scramfatal("No tool name given: see \"scram tool -help\" for usage info.")
+        SCRAM.scramfatal("No tool name given: see \"scram tool --help\" for usage info.")
 
     toolname = args[0].lower()
     toolmanager = ToolManager(area)


### PR DESCRIPTION
The message issued with a `scramfatal` suggests using `scram -help` to obtain info about the command, but this gives:
```
usage: scram.py [-a ARCH] [-f] [-v] [-h] [--debug]
scram.py: error: argument -h/--help: ignored explicit argument 'elp'
```
The correct option would be `--help`. This PR fixes the message printed when a `scramfatal` is encountered by adding the missing `-`. 